### PR TITLE
Fixed missing dependencies (ftsm)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Though is indicated as a dependency, you might need to manually install the cost
 sudo apt-get install ros-kinetic-costmap-converter
 ```
 
+The branch of `ropod-common` should be changed to `develop` branch if `catkin build` fails.
+
 Once the software is compiled at the robot, give access of raw ethercat data to the low-level-control executable. For instance:
 
 ```

--- a/install_software
+++ b/install_software
@@ -5,11 +5,12 @@ cd ropod-project-software/catkin_workspace/src
 git clone https://github.com/ropod-project/tree-ropod.git ./
 wstool init
 wstool up
-echo "source ~/ropod-project-software/catkin_workspace/src/platform/ropod_tue_1_bringup
-/setup.bash"  >> ~/.bashrc
+echo "source ~/ropod-project-software/catkin_workspace/src/platform/ropod_tue_1_bringup/setup.bash"  >> ~/.bashrc
 
 git clone git@git.ropod.org:ropod/ropod_common.git;
 sudo mv ropod_common /opt/ 
+git clone git@github.com:ropod-project/ftsm.git
+sudo mv ftsm /opt/ropod/
 
 cd ~
 wget https://raw.githubusercontent.com/blumenthal/ropod-base-cpp/master/install_deps.sh
@@ -19,7 +20,8 @@ cd /opt
 sudo mkdir ropod
 sudo mv ropod_common/ ropod
 
-source ~/ropod-project-software/catkin_workspace/src/platform/ropod_tue_1_bringup
-/setup.bash
-rosdep update;rosdep install --from-path . -i -y;
-cd ~/ropod-project-software/catkin_workspace; catkin_make;
+source ~/ropod-project-software/catkin_workspace/src/platform/ropod_tue_1_bringup/setup.bash
+rosdep update
+rosdep install --from-path . -i -y
+cd ~/ropod-project-software/catkin_workspace
+catkin build


### PR DESCRIPTION
**Changes**
- Fixed errors where a single line was split into 2 lines (line 8 and 23)
- Added ftsm repository in the `install_software` file 
- Replace `catkin_make` with `catkin build`
- Replaced multi-line commands to single line commands
- Added a note to change branch for `ropod-common` repository